### PR TITLE
feat(cft): add API Gateway and default stage for Lambda proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,84 @@
+```
+# Lambda CORS Proxy
+
+A lightweight, CORS Anywhere–style proxy deployed to AWS Lambda via CloudFormation. It forwards HTTP requests to a target URL, adds permissive CORS headers, and supports GET/POST/PUT/DELETE/etc.
+
+---
+
+## Features
+
+- Proxy any external API with full query and header support  
+- Adds permissive CORS headers (`Access-Control-Allow-Origin: *`)  
+- Blocks unwanted hosts via environment-configurable denylist  
+- Deployable via `make` and `template.yaml`  
+- Runs locally (`node src/handler.js`) or in AWS Lambda via API Gateway
+
+---
+
+## Project Structure
+
+src/  
+├── app.js                  # Express app setup  
+├── handler.js              # Lambda + local entry point  
+├── config/  
+│   └── allowed-hosts.js    # Host validation logic  
+├── middleware/             # CORS, security, rate-limiter  
+├── services/  
+│   └── proxy-service.js    # Core proxy logic  
+└── utils/  
+    └── error-handler.js    # Shared error response formatter
+
+---
+
+## Usage
+
+### Proxy Format
+
+Send requests in this format:  
+GET /<target-host>/<path>?<query>
+
+Example:  
+curl "https://your-api-id.execute-api.us-east-1.amazonaws.com/api.mexc.com/api/v3/depth?symbol=BTCUSDT"
+
+This will proxy to:  
+https://api.mexc.com/api/v3/depth?symbol=BTCUSDT
+
+---
+
+## Run Locally
+
+npm install  
+node src/handler.js
+
+Then:  
+curl "http://localhost:3000/api.mexc.com/api/v3/depth?symbol=BTCUSDT"
+
+---
+
+## Deployment
+
+### Build and Deploy Code
+
+make package     # Install and zip Lambda function  
+make deploy      # Upload function code to AWS Lambda
+
+### First-Time CloudFormation Deployment
+
+aws cloudformation deploy \  
+  --template-file template.yaml \  
+  --stack-name cors-proxy \  
+  --capabilities CAPABILITY_IAM
+
+---
+
+## Environment Configuration
+
+Block specific domains using the `BLOCKED_HOSTS` environment variable:  
+BLOCKED_HOSTS=localhost,127.0.0.1
+
+---
+
+## License
+
+MIT
+```

--- a/template.yaml
+++ b/template.yaml
@@ -31,7 +31,33 @@ Resources:
       MemorySize: 512
       Timeout: 15
 
+  ApiGateway:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: CORSProxyAPI
+      ProtocolType: HTTP
+      Target: !GetAtt NodeLambdaFunction.Arn
+
+  ApiGatewayPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref NodeLambdaFunction
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${ApiGateway}/*/*/*
+
+  ApiGatewayStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref ApiGateway
+      StageName: $default
+      AutoDeploy: true
+
 Outputs:
   FunctionName:
     Description: "Lambda Function Name"
     Value: !Ref NodeLambdaFunction
+
+  ApiEndpoint:
+    Description: "API Gateway HTTPS Endpoint"
+    Value: !Sub "https://${ApiGateway}.execute-api.${AWS::Region}.amazonaws.com"


### PR DESCRIPTION
- Added AWS::ApiGatewayV2::Api to expose Lambda via HTTP

- Configured $default stage for clean URLs (no /prod prefix)

- Added Lambda invoke permission for API Gateway

- Included API endpoint in CloudFormation outputs
