### PR TITLE
fix(README.md): remove backtick to restore markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-```
 # Lambda CORS Proxy
 
 A lightweight, CORS Anywhere–style proxy deployed to AWS Lambda via CloudFormation. It forwards HTTP requests to a target URL, adds permissive CORS headers, and supports GET/POST/PUT/DELETE/etc.
@@ -81,4 +80,3 @@ BLOCKED_HOSTS=localhost,127.0.0.1
 ## License
 
 MIT
-```


### PR DESCRIPTION
This PR removes the triple backtick wrapper from the README.md file, which was incorrectly causing the entire document to render as a code block on GitHub.

Changes
Removed opening and closing ``` lines around the markdown content

