### PR TITLE
feat(makefile): add local HTTPS support with cert generation and dev …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Build and deployment control
-.PHONY: full clean package deploy help
+.PHONY: full clean package deploy install local cert help
 
 # Full deployment pipeline
 full: clean package deploy
@@ -34,3 +34,19 @@ deploy: package
 		--function-name cors-proxy \
 		--zip-file fileb://dist/function.zip
 	@echo "✅ Lambda updated"
+
+# Generate self-signed certs for local HTTPS
+cert:
+	@echo "Generating self-signed certs..."
+	@mkdir -p cert
+	@openssl req -x509 -newkey rsa:2048 -nodes \
+		-keyout cert/key.pem \
+		-out cert/cert.pem \
+		-days 365 \
+		-subj "/CN=localhost"
+	@echo "🔐 Certs generated"
+
+# Run local server (assumes certs and handler already exist)
+local: install cert
+	@echo "Starting local HTTPS server..."
+	@npm run start:dev

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,17 +1,34 @@
 const awsServerlessExpress = require('aws-serverless-express');
+const fs = require('fs');
+const http = require('http');
+const https = require('https');
 const app = require('./app');
 
 const server = awsServerlessExpress.createServer(app);
 
 // Lambda handler
-exports.handler = (event, context) => {
+exports.handler = async (event, context) => {
   return awsServerlessExpress.proxy(server, event, context);
 };
 
-// Local-only: skip if running in Lambda
+// Local-only: HTTPS with fallback to HTTP
 if (!process.env.AWS_LAMBDA_FUNCTION_NAME) {
   const port = process.env.PORT || 3000;
-  app.listen(port, () => {
-    console.log(`Local server running at http://localhost:${port}`);
-  });
+
+  const certPath = './cert/cert.pem';
+  const keyPath = './cert/key.pem';
+
+  if (fs.existsSync(certPath) && fs.existsSync(keyPath)) {
+    const options = {
+      cert: fs.readFileSync(certPath),
+      key: fs.readFileSync(keyPath),
+    };
+    https.createServer(options, app).listen(port, () => {
+      console.log(`Local HTTPS server running at https://localhost:${port}`);
+    });
+  } else {
+    http.createServer(app).listen(port, () => {
+      console.log(`Local HTTP server running at http://localhost:${port}`);
+    });
+  }
 }


### PR DESCRIPTION
Adds Makefile targets to support local HTTPS testing:
- `make cert` generates a self-signed cert in ./cert
- `make local` installs deps, generates certs if needed, and starts the dev server over HTTPS

Improves local parity with deployed Lambda environment.
